### PR TITLE
Added ability to pass custom headers in request. Fixes issue #47.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ var uploader = new ss.SimpleUpload({
 * Use any HTML element as the upload button
 * No dependencies - use it with or without jQuery
 * Provides individual callback functions for XHR-supported browsers and for browsers that do not support XHR uploads
+* Ability to pass custom headers in request such as the Authorization header
 
 ### Server-side file handling ###
 Files are uploaded by POST as either raw form data or regular multipart/form-data, depending on the browser.
@@ -130,7 +131,7 @@ var uploader = new ss.SimpleUpload({
        // Do something after finishing the upload
        // Note that the progress bar will be automatically removed upon completion because everything 
        // is encased in the "wrapper", which was designated to be removed with setProgressContainer() 
-      onComplete:	function(filename, response) {
+      onComplete:   function(filename, response) {
           if (!response) {
             alert(filename + 'upload failed');
             return false;
@@ -201,9 +202,9 @@ $Upload = new FileUpload('uploadfile');
 $result = $Upload->handleUpload($upload_dir, $valid_extensions);
 
 if (!$result) {
-	echo json_encode(array('success' => false, 'msg' => $Upload->getErrorMsg()));	
+    echo json_encode(array('success' => false, 'msg' => $Upload->getErrorMsg()));   
 } else {
-	echo json_encode(array('success' => true, 'file' => $Upload->getFileName()));
+    echo json_encode(array('success' => true, 'file' => $Upload->getFileName()));
 }
 ```
 
@@ -226,6 +227,18 @@ if ($result) {
   $imgsize = getimagesize($path);
   // image resizing stuff...
 }
+```
+
+### Passing Custom Headers ###
+
+You can pass custom headers in the options upon initialization:
+
+```javascript
+var uploader = new ss.SimpleUpload({
+    customHeaders: {'Authorization': 'my-access-token'},
+    ...
+});
+
 ```
 
 ### License ###

--- a/SimpleAjaxUploader.js
+++ b/SimpleAjaxUploader.js
@@ -442,6 +442,7 @@ ss.SimpleUpload = function( options ) {
     hoverClass: '',
     focusClass: '',
     disabledClass: '',
+    customHeaders: [],
     onAbort: function( filename, uploadBtn ) {},
     onChange: function( filename, extension, uploadBtn ) {},
     onSubmit: function( filename, extension, uploadBtn ) {},
@@ -1133,6 +1134,11 @@ ss.SimpleUpload.prototype = {
 
     if ( opts.responseType.toLowerCase() == 'json' ) {
       xhr.setRequestHeader( 'Accept', 'application/json, text/javascript, */*; q=0.01' );
+    }
+
+    // Set custom request headers
+    for ( var headerName in opts.customHeaders ) {
+        xhr.setRequestHeader( headerName, opts.customHeaders[headerName] );
     }
 
     if ( opts.multipart === true ) {


### PR DESCRIPTION
I love this uploader and had a real need to be able to use custom headers (specifically the Authorization header) similar to another request you had received here: https://github.com/LPology/Simple-Ajax-Uploader/issues/47. I went ahead and modified my copy and realized it was fairly simple to address this, so am submitting a pull request with the changes. I added documentation to the README.md file and there were a few incidental spacing changes in SimpleAjaxUploader.js. As I am not sure what you use for minification, I figured it best to let you uglify it as you see fit. 
