### PR TITLE
Correct input multiple flag

### DIFF
--- a/SimpleAjaxUploader.js
+++ b/SimpleAjaxUploader.js
@@ -755,7 +755,7 @@ ss.SimpleUpload.prototype = {
 
     // Don't allow multiple file selection in Safari -- it has a nasty bug
     // http://stackoverflow.com/q/7231054/1091949
-    if ( XhrOk && !isSafari && this._input.multiple ) {
+    if ( XhrOk && !isSafari && this._opts.multiple ) {
       this._input.multiple = true;
     }
 


### PR DESCRIPTION
Allow the input multiple only if the options multiple is set to true in the options.

Overwise, you can always select multiple files, even if only one is being uploaded.
