### PR TITLE
Fixed uploading files with cyrillic names

### DIFF
--- a/SimpleAjaxUploader.js
+++ b/SimpleAjaxUploader.js
@@ -1420,7 +1420,7 @@ ss.XhrUpload = {
 
         for ( var i in headers ) {
             if ( headers.hasOwnProperty( i ) ) {
-                xhr.setRequestHeader( i, headers[ i ] + '' );
+                xhr.setRequestHeader( i, encodeURIComponent(headers[ i ]) + '' );
             }
         }
 


### PR DESCRIPTION
Fixed uploading files with cyrillic names. 

Uncaught SyntaxError: Failed to execute 'setRequestHeader' on 'XMLHttpRequest': 'Віртуальність.mp3' is not a valid HTTP header field value.