### PR TITLE
Fixing relative path security vulnerability

### DIFF
--- a/extras/Uploader.php
+++ b/extras/Uploader.php
@@ -65,6 +65,8 @@ class FileUpload {
                 $this->fileExtension = strtolower($pathinfo['extension']);
                 $this->fileNameWithoutExt = $pathinfo['filename'];
             }
+            
+            $this->fileName = str_replace(array('/','\\'),'_',$this->fileName);
         }
     }
 


### PR DESCRIPTION
A malicious user is able to save the file outside the upload directory simple by changing the X-File-Name header to something like this: ../../test.txt