### PR TITLE
Add option not to URI-encode custom request headers

### DIFF
--- a/SimpleAjaxUploader.js
+++ b/SimpleAjaxUploader.js
@@ -497,6 +497,7 @@ ss.SimpleUpload = function( options ) {
         focusClass: '',
         disabledClass: '',
         customHeaders: {},
+        encodeCustomHeaders: true,
         onAbort: function( filename, uploadBtn ) {},
         onChange: function( filename, extension, uploadBtn, size ) {},
         onSubmit: function( filename, extension, uploadBtn, size ) {},
@@ -1421,7 +1422,14 @@ ss.XhrUpload = {
 
         for ( var i in headers ) {
             if ( headers.hasOwnProperty( i ) ) {
-                xhr.setRequestHeader( i, encodeURIComponent(headers[ i ]) + '' );
+                var headerValue = headers[ i ];
+                // URI-encode if encodeCustomHeaders option is true or current header is not from customHeaders option
+                if (opts.encodeCustomHeaders || !opts.customHeaders.hasOwnProperty( i )) {
+                    headerValue = encodeURIComponent(headerValue);
+                }
+
+                xhr.setRequestHeader( i, headerValue + '' );
+
             }
         }
 


### PR DESCRIPTION
I use Yii framework and encountered an issue with hard-coded URI-encoding of `customHeaders` option values. It brakes the CSRF token verification.

This simple patch makes URI-encoding optional. Also, resolves #93 