### PR TITLE
Fix onChange 3rd argument not button bug

### DIFF
--- a/SimpleAjaxUploader.js
+++ b/SimpleAjaxUploader.js
@@ -1315,7 +1315,7 @@ ss.XhrUpload = {
             ext = ss.getExt( filename );
             size = Math.round( files[i].size / 1024 );
 
-            if ( false === this._opts.onChange.call( this, filename, ext, size ) ) {
+            if ( false === this._opts.onChange.call( this, filename, ext, this._overBtn, size ) ) {
                 return false;
             }
 


### PR DESCRIPTION
When using XHR for upload, the `onChange()` event handler is called with the size as 3rd argument not the `uploadBtn`, rendering the API inconsistant.

The fix is very simple as shown by this pull request.