### PR TITLE
Update SimpleAjaxUploader.js

### DIFF
--- a/SimpleAjaxUploader.js
+++ b/SimpleAjaxUploader.js
@@ -1561,7 +1561,7 @@ ss.XhrUpload = {
         params[this._opts.name] = fileObj.name;
 
         headers['X-Requested-With'] = 'XMLHttpRequest';
-        headers['X-File-Name'] = !this._opts.encodeCustomHeaders ? fileObj.name : encodeURIComponent( fileObj.name );
+        headers['X-File-Name'] = encodeURIComponent( fileObj.name );
 
         if ( this._opts.responseType.toLowerCase() == 'json' ) {
             headers['Accept'] = 'application/json, text/javascript, */*; q=0.01';


### PR DESCRIPTION
I think the file name should always be encoded. This is an easy fix, however, I’m not sure whether it conflicts with the logic behind the opts.customHeaders or not.