### PR TITLE
For multiple file uploads, example code was buggy

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,12 @@ var uploader = new ss.SimpleUpload({
               bar = document.createElement('div'), // actual progress bar
               fileSize = document.createElement('div'), // container for upload file size
               wrapper = document.createElement('div'), // container for this progress bar
-              progressBox = document.getElementById('progressBox'); // on page container for progress bars
+              //declare somewhere: <div id="progressBox"></div> where you want to show the progress-bar(s)
+              progressBox = document.getElementById('progressBox'); //on page container for progress bars
           
           // Assign each element its corresponding class
-          progress.className = 'progress';
-          bar.className = 'bar';            
+          progress.className = 'progress progress-striped';
+          bar.className = 'progress-bar progress-bar-success';
           fileSize.className = 'size';
           wrapper.className = 'wrapper';
           

--- a/SimpleAjaxUploader.js
+++ b/SimpleAjaxUploader.js
@@ -2029,7 +2029,7 @@ ss.extendObj( ss.SimpleUpload.prototype, {
         // We have to do it here after everything is finished to avoid any errors
         if ( this._destroy &&
              this._queue.length === 0 &&
-             this._active.length === 0 )
+             this._active === 0 )
         {
             for ( var prop in this ) {
                 if ( this.hasOwnProperty( prop ) ) {


### PR DESCRIPTION
2. Updating this._active.length to this._active, as its a integer variable. Destroy wont get called if "this._active.length === 0 " is checked as  AND condition.

1. For multiple file uploads, the example code shown here showed the progress bar(s), but never '"FILLED" any of them at all. The CSS wasn't getting recognized somehow, might be a bootstrap version upgrade problem.