### PR TITLE
HTML5 dragleave fired when hovering a child element

### DIFF
--- a/SimpleAjaxUploader.js
+++ b/SimpleAjaxUploader.js
@@ -1849,6 +1849,7 @@ ss.DragAndDrop = {
 
     addDropZone: function( elem ) {
         var self = this;
+        var depthCounter = 0;
 
         ss.addStyles( elem, {
             'zIndex': 16777271
@@ -1863,6 +1864,7 @@ ss.DragAndDrop = {
             }
 
             ss.addClass( this, self._opts.dragClass );
+            depthCounter++;
             return false;
         };
 
@@ -1878,7 +1880,10 @@ ss.DragAndDrop = {
         };
 
         elem.ondragleave = function() {
-            ss.removeClass( this, self._opts.dragClass );
+            depthCounter--;
+            if (depthCounter === 0){
+              ss.removeClass( this, self._opts.dragClass );
+            }
             return false;
         };
 


### PR DESCRIPTION
The problem I'm trying to fix is that the `dragleave event` of an element is fired when hovering a child element of that element. Both the parent and child are in the `dropzone` parameter like 
`dropzone: $('.droppAble')`

A seemingly god solution is described on [stackoverflow](http://stackoverflow.com/questions/7110353/html5-dragleave-fired-when-hovering-a-child-element)

cheers