### PR TITLE
bug fixed: set nginx request incorrect in IE 9

### DIFF
--- a/SimpleAjaxUploader.js
+++ b/SimpleAjaxUploader.js
@@ -1223,17 +1223,18 @@ ss.IframeUpload = {
             iframeLoaded = false,
             cancel;
 
-        if ( opts.noParams === true ) {
-            url = opts.url;
-
-        } else {
-            // If we're using Nginx Upload Progress Module, append upload key to the URL
-            // Also, preserve query string if there is one
-            url = !opts.nginxProgressUrl ?
-                    opts.url :
-                    url + ( ( url.indexOf( '?' ) > -1 ) ? '&' : '?' ) +
-                          encodeURIComponent( opts.nginxProgressHeader ) + '=' + encodeURIComponent( key );
-        }
+        // if ( opts.noParams === true ) {
+        //     url = opts.url;
+        //
+        // } else {
+        //     // If we're using Nginx Upload Progress Module, append upload key to the URL
+        //     // Also, preserve query string if there is one
+        //     url = !opts.nginxProgressUrl ?
+        //             opts.url :
+        //             url + ( ( url.indexOf( '?' ) > -1 ) ? '&' : '?' ) +
+        //                   encodeURIComponent( opts.nginxProgressHeader ) + '=' + encodeURIComponent( key );
+        // }
+        url = !opts.nginxProgressUrl ? opts.url : opts.url + ((opts.url.indexOf('?') > -1) ? '&' : '?') + encodeURIComponent(opts.nginxProgressHeader) + '=' + encodeURIComponent(key);
 
         form = ss.getForm({
             action: url,


### PR DESCRIPTION
NoParams option seems has no relation to a fallback with legacy browsers.

Besides, upload request should contains 'X-Progress-ID', and since we cannot set headers in 'iframe' request, we could only append it to the query.

