### PR TITLE
removing display from the hidden elements

### DIFF
--- a/SimpleAjaxUploader.js
+++ b/SimpleAjaxUploader.js
@@ -1998,7 +1998,7 @@ ss.extendObj( ss.SimpleUpload.prototype, {
         }
 
         ss.addStyles( div, {
-            'display' : 'block',
+            'display' : 'none',
             'position' : 'absolute',
             'overflow' : 'hidden',
             'margin' : 0,


### PR DESCRIPTION
removing the hidden elements being displayed - this breaks on multi page forms such as experian giving you all sorts of white space issues the go further than the body.

I've tested functionality and it seems to be just fine without showing these